### PR TITLE
Add Terraform support for Route53 resolver in egress VPC

### DIFF
--- a/roots/rosa_privatelink_sts_3azs/main-route53.tf
+++ b/roots/rosa_privatelink_sts_3azs/main-route53.tf
@@ -1,0 +1,48 @@
+data "aws_route53_zone" "private_rosa_dns_zone" {
+  name         = "${ocm_cluster_rosa_classic.rosa.domain}"
+  private_zone = true
+
+  depends_on = [ocm_cluster_wait.rosa]
+}
+
+resource "aws_route53_zone_association" "egress-rosa-resolver-vpc-assotiation" {
+  zone_id = data.aws_route53_zone.private_rosa_dns_zone.id
+  vpc_id  = aws_vpc.egress-vpc.id
+}
+
+resource "aws_security_group" "rosa-resolution-sg" {
+  name        = "allow-dns"
+  description = "Allow DNS inbound traffic"
+  vpc_id      = aws_vpc.egress-vpc.id
+
+  ingress {
+    description      = "DNS (TCP)"
+    from_port        = 53
+    to_port          = 53
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description      = "DNS (UDP)"
+    from_port        = 53
+    to_port          = 53
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_route53_resolver_endpoint" "rosa-resolver-inbound-endpoint" {
+  name      = "rosa-resolver-inbound-endpoint"
+  direction = "INBOUND"
+
+  security_group_ids = [aws_security_group.rosa-resolution-sg.id]
+
+  dynamic "ip_address" {
+    for_each = data.aws_availability_zones.azs.names
+    content {
+      subnet_id = aws_subnet.egress-subnet-pub[ip_address.value].id  
+    }
+  }
+}
+

--- a/roots/rosa_privatelink_sts_3azs/output-route53.tf
+++ b/roots/rosa_privatelink_sts_3azs/output-route53.tf
@@ -1,0 +1,3 @@
+output "rosa_private_zone_domain_UNDOCUMENTED" {
+    value     = "${ocm_cluster_rosa_classic.rosa.domain}"
+}

--- a/roots/rosa_privatelink_sts_3azs/output.tf
+++ b/roots/rosa_privatelink_sts_3azs/output.tf
@@ -2,6 +2,10 @@ output "bastion_ip" {
     value = "${aws_instance.egress-vpc-bastion.public_ip}"
 }
 
+output "private_bastion_ip" {
+    value= "${aws_instance.rosa-vpc-bastion.private_ip}"
+}
+
 output "bastion_private_key" {
     value     = tls_private_key.ssh.private_key_pem
     sensitive = true


### PR DESCRIPTION
Route53 add on to configure ROSA VCP hostez zone resolver in egress VPC. 